### PR TITLE
Cache viewed notifications in local storage

### DIFF
--- a/src/js/pages/attendee/Home.jsx
+++ b/src/js/pages/attendee/Home.jsx
@@ -39,8 +39,8 @@ export default class Featured extends React.Component {
   };
 
   getNotifications() {
-    let unexpired = NotificationStore.getUnexpired();
-    this.setState({notifications: unexpired});
+    let validNotifications = NotificationStore.getValid();
+    this.setState({notifications: validNotifications});
   };
 
   showNotificationStoreError() {

--- a/src/js/stores/NotificationStore.jsx
+++ b/src/js/stores/NotificationStore.jsx
@@ -11,7 +11,6 @@ class NotificationStore extends EventEmitter {
   constructor() {
     super()
     this.notifications = [];
-    this.viewedNotifications = JSON.parse(localStorage.getItem("viewedNotifications"));
     this.error = null;
   }
 

--- a/src/js/stores/NotificationStore.jsx
+++ b/src/js/stores/NotificationStore.jsx
@@ -11,6 +11,7 @@ class NotificationStore extends EventEmitter {
   constructor() {
     super()
     this.notifications = [];
+    this.viewedNotifications = JSON.parse(localStorage.getItem("viewedNotifications"));
     this.error = null;
   }
 
@@ -37,12 +38,22 @@ class NotificationStore extends EventEmitter {
     return self.notifications;
   }
 
-  getUnexpired() {
+  getValid() {
     var self = this;
     const currTime = moment().unix();
+
+    // Check Expiry time
     self.notifications = self.notifications.filter((notification) => {
       return notification.expirytime > currTime;
     });
+
+    // Check if Notifications have already been seen
+    const viewedNotifications = JSON.parse(localStorage.getItem("viewedNotifications"));
+    if (viewedNotifications) {
+      self.notifications = self.notifications.filter((notification) => {
+        return !(viewedNotifications.includes(notification.id));
+      });
+    }
 
     self.notifications = self.notifications.map((notification) => {
       return {
@@ -66,6 +77,15 @@ class NotificationStore extends EventEmitter {
     self.notifications = self.notifications.filter((notification) => {
       return notification.id != notificationParam.id;
     });
+
+    // Set this notification as viewed so it doesn't appear again
+    let viewedNotifications = JSON.parse(localStorage.getItem("viewedNotifications"));
+    if (viewedNotifications == null) {
+      viewedNotifications = [];
+    }
+    viewedNotifications.push(notificationParam.id);
+    localStorage.setItem("viewedNotifications", JSON.stringify(viewedNotifications));
+
     dispatcher.dispatch({type: "NOTIFICATIONS_GET"});
     return self.notifications;
   }


### PR DESCRIPTION
Stop users from getting bombarded with messages each time they use the app...

I guess there isn't an easy way for this to work devices? i.e. at the account level?

### Test

Would like to test with more than one notification... Anyone have the POST handy for notifications?