### PR TITLE
Add region to aws sync

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,4 +20,4 @@ deployment:
   production:
     branch: master
     commands:
-      - aws s3 sync build s3://calligre-attendee-web/ --delete
+      - aws s3 sync build s3://calligre-attendee-web/ --delete --region us-west-2


### PR DESCRIPTION
If we ever deploy the attendee-web stuff to a bucket in a new AWS region (ie Canada, Ohio, etc), the CLI complains about needing to use Signature v4.

AWS isn't following their own best practices. Whoop.