### PR TITLE
Check if Integrations have been loaded

### DIFF
--- a/src/js/components/CreatePost.jsx
+++ b/src/js/components/CreatePost.jsx
@@ -18,12 +18,13 @@ export default class NewsFeed extends React.Component {
     const integrations = AuthService.getProfile().identities;
     let fbIntegration = false;
     let twIntegration = false;
-
-    for (let integration of integrations) {
-      if (integration.connection === 'facebook') {
-        fbIntegration = true;
-      } else if (integration.connection === 'twitter') {
-        twIntegration = true;
+    if (integrations) {
+      for (let integration of integrations) {
+        if (integration.connection === 'facebook') {
+          fbIntegration = true;
+        } else if (integration.connection === 'twitter') {
+          twIntegration = true;
+        }
       }
     }
 

--- a/src/js/pages/attendee/NewsFeed.jsx
+++ b/src/js/pages/attendee/NewsFeed.jsx
@@ -17,9 +17,6 @@ export default class NewsFeed extends React.Component {
         // nextOffset is stored in the NewsFeedStore
       },
       imageOverlay: null,
-      // TODO: HOW CAN I GET THESE? (If user is integrated into social media channels)
-      twIntegration: true,
-      fbIntegration: true,
       preferences: PreferenceStore.getDefaults(),
     };
     PreferenceStore.loadAll();
@@ -90,9 +87,7 @@ export default class NewsFeed extends React.Component {
   render() {
     const {
       contentFeed,
-      fbIntegration,
       imageOverlay,
-      twIntegration,
       preferences,
     } = this.state;
 


### PR DESCRIPTION
There was an error iterating over integrations if user didn't have permission to load them... (aka they weren't logged in)

Is there a way to prevent these components from even loading if the user isn't logged in?